### PR TITLE
Add IAM permissions to tiko_nudge_reminders

### DIFF
--- a/iam/policies.tf
+++ b/iam/policies.tf
@@ -65,6 +65,7 @@ data "aws_iam_policy_document" "tiko_nudge_reminders" {
     actions = local.publish_queue
 
     resources = [
+        data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-second-test"],
       data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-handle-inbound-message-command"],
       data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-scheduler-commands"],
       data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-chatter-send-message"],
@@ -81,6 +82,7 @@ data "aws_iam_policy_document" "tiko_nudge_reminders" {
     actions = local.consume_queue
 
     resources = [
+        data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-second-test"],
       data.terraform_remote_state.sqs_sns.outputs.queue_arns["${var.environment}-tiko-nudge-reminders-service"]
     ]
 
@@ -92,6 +94,7 @@ data "aws_iam_policy_document" "tiko_nudge_reminders" {
     actions = local.publish_topic
 
     resources = [
+        data.terraform_remote_state.sqs_sns.outputs.topic_arns["${var.environment}-second-test"],
       data.terraform_remote_state.sqs_sns.outputs.topic_arns["${var.environment}-reminder-sent"]
     ]
 


### PR DESCRIPTION
Add IAM permissions for second-test in publish_queue,consume_queue